### PR TITLE
Change application to use scheduler instead of a Timer.

### DIFF
--- a/src/main/java/com/tarterware/roadrunner/RoadrunnerApplication.java
+++ b/src/main/java/com/tarterware/roadrunner/RoadrunnerApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
+@EnableScheduling
 public class RoadrunnerApplication
 {
     public static void main(String[] args)

--- a/src/main/java/com/tarterware/roadrunner/components/VehicleManager.java
+++ b/src/main/java/com/tarterware/roadrunner/components/VehicleManager.java
@@ -2,19 +2,17 @@ package com.tarterware.roadrunner.components;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -26,11 +24,13 @@ import org.locationtech.proj4j.CoordinateTransform;
 import org.locationtech.proj4j.ProjCoordinate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.convert.DurationStyle;
 import org.springframework.core.env.Environment;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.tarterware.roadrunner.models.TripPlan;
@@ -70,21 +70,21 @@ public class VehicleManager
     // Template to use redis.
     private RedisTemplate<String, Object> redisTemplate;
 
-    // Update period in milliseconds.
-    private long msPeriod = 100;
+    // TODO - wire this up to an applications-property (not working atm)
+    // @Value("${com.tarterware.roadrunner.updateperiod}")
+    private String msPeriodString = "100";
 
-    // Timer to schedule periodic updates.
-    private Timer timer;
+    // Update period in milliseconds.
+    private long msPeriod;
 
     // Hostname where this manager is running
     private String hostName;
 
     // Map of Directions by Vehicle ID.
-    private Map<UUID, Directions> directionsMap = Collections.synchronizedMap(new HashMap<UUID, Directions>());
+    private final ConcurrentMap<UUID, Directions> directionsMap = new ConcurrentHashMap<UUID, Directions>();
 
     // LineSegmentData by Vehicle ID.
-    private Map<UUID, List<LineSegmentData>> lineSegmentDataMap = Collections
-            .synchronizedMap(new HashMap<UUID, List<LineSegmentData>>());
+    private final ConcurrentMap<UUID, List<LineSegmentData>> lineSegmentDataMap = new ConcurrentHashMap<UUID, List<LineSegmentData>>();
 
     // Service to retrieve directions for trip plans
     private DirectionsService directionsService;
@@ -140,15 +140,10 @@ public class VehicleManager
             logger.error("Unable to determine hostName!  Setting manager host to UNKNOWN");
             this.hostName = "UNKNOWN";
         }
-
-        // Check for "test" profile
-        if (Arrays.asList(environment.getActiveProfiles()).contains("test"))
-        {
-            logger.info("Running in test mode. Skipping startup.");
-            return;
-        }
-
-        startup();
+        // DurationStyle.detect() determines the style (e.g., SIMPLE, ISO-8601) based on
+        // the string
+        Duration duration = DurationStyle.detect(msPeriodString).parse(msPeriodString);
+        msPeriod = duration.toMillis();
     }
 
     /**
@@ -162,7 +157,7 @@ public class VehicleManager
     }
 
     /**
-     * Gets the map of all Vehicles.
+     * Gets a paginated map of Vehicles.
      *
      * @param page     page number to retrieve.
      * @param pageSize number of Vehicles in each page.
@@ -170,11 +165,6 @@ public class VehicleManager
      */
     public Map<UUID, Vehicle> getVehicleMap(int page, int pageSize)
     {
-        if (!isRunning())
-        {
-            startup();
-        }
-
         // Create a Map of Vehicles to return
         Map<UUID, Vehicle> vMap = new HashMap<UUID, Vehicle>();
 
@@ -220,7 +210,7 @@ public class VehicleManager
      */
     public Vehicle getVehicle(UUID uuid)
     {
-        String key = VEHICLE_PREFIX + uuid.toString();
+        String key = getVehicleKey(uuid);
 
         Vehicle vehicle = (Vehicle) redisTemplate.opsForValue().get(key);
 
@@ -229,7 +219,7 @@ public class VehicleManager
 
     private void setVehicle(Vehicle vehicle)
     {
-        String key = VEHICLE_PREFIX + vehicle.getId().toString();
+        String key = getVehicleKey(vehicle.getId());
 
         // Add a marker that this manager calculated the vehicle state.
         vehicle.setManagerHost(hostName);
@@ -238,79 +228,6 @@ public class VehicleManager
 
         // Add it to the set of Vehicles to be updated.
         redisTemplate.opsForZSet().add(VEHICLE_QUEUE, vehicle.getId().toString(), vehicle.lastCalculationEpochMillis);
-    }
-
-    /**
-     * Starts the VehicleManager, initiating periodic updates.
-     */
-    public void startup()
-    {
-        if (timer != null)
-        {
-            throw new IllegalStateException("VehicleManager has already started!");
-        }
-
-        Random random = new Random();
-        long msDelay = (long) (msPeriod * random.nextDouble());
-        logger.info("Starting VehicleManager with period of " + msPeriod + " ms and delay of " + msDelay + " ms.");
-
-        timer = new Timer("VehicleManager Timer");
-        timer.schedule(new UpdateTask(), msDelay, msPeriod);
-    }
-
-    /**
-     * Stops the VehicleManager and clears all managed Vehicles.
-     */
-    public void shutdown()
-    {
-        if (timer == null)
-        {
-            throw new IllegalStateException("VehicleManager is not running!");
-        }
-
-        timer.cancel();
-        timer = null;
-    }
-
-    /**
-     * Checks if the VehicleManager is running.
-     *
-     * @return True if the manager is running, false otherwise.
-     */
-    public boolean isRunning()
-    {
-        return timer != null;
-    }
-
-    /**
-     * Gets the update period in milliseconds.
-     *
-     * @return The update period.
-     */
-    public long getMsPeriod()
-    {
-        return msPeriod;
-    }
-
-    /**
-     * Sets the update period. Restarts the manager if it is running.
-     *
-     * @param value The new update period in milliseconds.
-     */
-    public void setMsPeriod(long value)
-    {
-        boolean wasRunning = isRunning();
-        if (wasRunning)
-        {
-            shutdown();
-        }
-
-        msPeriod = value;
-
-        if (wasRunning)
-        {
-            startup();
-        }
     }
 
     /**
@@ -342,7 +259,7 @@ public class VehicleManager
         // Add the vehicle to the Active Vehicle Registry
         redisTemplate.opsForSet().add(ACTIVE_VEHICLE_REGISTRY, vehicle.getId().toString());
 
-        logger.info("Created vehicle ID " + vehicle.getId());
+        logger.info("Created vehicle ID {}", vehicle.getId());
 
         return vehicle;
     }
@@ -483,107 +400,104 @@ public class VehicleManager
         return lineSegmentDataMap.get(vehicleId);
     }
 
-    /**
-     * TimerTask implementation to update the state of all Vehicles periodically.
-     */
-    class UpdateTask extends TimerTask
+    private String getVehicleKey(UUID vehicleId)
     {
-        @Override
-        public void run()
+        return VEHICLE_PREFIX + vehicleId.toString();
+    }
+
+    @Scheduled(fixedRateString = "100")
+    public void updateVehicles()
+    {
+        long nsManagerStartTime = System.nanoTime();
+        long currentEpochMillis = Instant.now().toEpochMilli();
+        long msEpochTimeoutTime = currentEpochMillis - (1000 * SECS_VEHICLE_TIMEOUT);
+
+        Set<UUID> deletionSet = new HashSet<>();
+
+        try
         {
-            long nsManagerStartTime = System.nanoTime();
-            long msManagerStartTime = Instant.now().toEpochMilli();
-            long msEpochTimeoutTime = msManagerStartTime - (1000 * SECS_VEHICLE_TIMEOUT);
-
-            Set<UUID> deletionSet = new HashSet<UUID>();
-
-            // Fetch and claim ready vehicles.We are looking for Vehicles that were
-            // process msPeriod milliseconds ago or earlier.
-            Set<ZSetOperations.TypedTuple<Object>> readyVehicles = redisTemplate.opsForZSet()
-                    .rangeByScoreWithScores(VEHICLE_QUEUE, 0, msManagerStartTime - msPeriod);
-
+            Set<ZSetOperations.TypedTuple<Object>> readyVehicles = fetchReadyVehicles(currentEpochMillis);
             if (readyVehicles != null)
             {
                 for (ZSetOperations.TypedTuple<Object> tuple : readyVehicles)
                 {
-                    long nsVehicleStartTime = System.nanoTime();
-
-                    UUID vehicleId = UUID.fromString((String) tuple.getValue());
-
-                    // Atomically remove from queue
-                    redisTemplate.opsForZSet().remove(VEHICLE_QUEUE, vehicleId.toString());
-
-                    Vehicle vehicle = getVehicle(vehicleId);
-
-                    // Retrieve Directions and LineSegmentData for this Vehicle.
-                    vehicle.setDirections(getVehicleDirections(vehicleId));
-                    vehicle.setListLineSegmentData(lineSegmentDataMap.get(vehicleId));
-
-                    // Perform the update.
-                    boolean updated = vehicle.update();
-
-                    // If the vehicle updated, then send the state to redis.
-                    if (updated)
-                    {
-                        long nsVehicleEndTime = System.nanoTime();
-                        vehicle.setLastNsExecutionTime(nsVehicleEndTime - nsVehicleStartTime);
-                        setVehicle(vehicle);
-                    }
-                    else
-                    {
-                        // If this vehicle hasn't been updated in SECS_VEHICLE_TIMEOUT seconds, then add
-                        // it to the deletion list
-                        if (vehicle.getLastCalculationEpochMillis() < msEpochTimeoutTime)
-                        {
-                            // Add this vehicle to the remove list so that the derived data can be deleted.
-                            deletionSet.add(vehicleId);
-                            logger.info("Deleting vehicle ID " + vehicle.getId());
-                        }
-                        else
-                        {
-                            setVehicle(vehicle);
-                        }
-                    }
+                    processVehicle(tuple, deletionSet, msEpochTimeoutTime);
                 }
             }
 
-            // Remove the deleted Vehicle IDs from the Active Vehicle Registry.
-            for (UUID vehicleID : deletionSet)
-            {
-                redisTemplate.opsForSet().remove(ACTIVE_VEHICLE_REGISTRY, vehicleID.toString());
-            }
+            cleanupDeletedVehicles(deletionSet);
 
-            // Remove the Directions for deleted Vehicles from the directionsMap.
-            synchronized (directionsMap)
-            {
-                for (UUID vehicleID : deletionSet)
-                {
-                    directionsMap.remove(vehicleID);
-                }
-            }
-
-            // Remove the LineSegmentData for deleted Vehicles from the lineSegmentDataMap.
-            synchronized (lineSegmentDataMap)
-            {
-                for (UUID vehicleID : deletionSet)
-                {
-                    lineSegmentDataMap.remove(vehicleID);
-                }
-            }
-
-            // Remove the deleted Vehicle IDs from the active Vehicles.
-            for (UUID vehicleID : deletionSet)
-            {
-                String key = VEHICLE_PREFIX + vehicleID.toString();
-                redisTemplate.opsForValue().getAndDelete(key);
-            }
-
-            // Calculate the execution time, and convert it to milliseconds
-            long nsManagerEndTime = System.nanoTime();
-            double msExecutionTime = (nsManagerEndTime - nsManagerStartTime) / 1_000_000.0;
-
-            // Update the gauge with the latest execution time
+            double msExecutionTime = (System.nanoTime() - nsManagerStartTime) / 1_000_000.0;
             msLatestExecutionTime.set(msExecutionTime);
         }
+        catch (Exception ex)
+        {
+            logger.error("Exception encountered during vehicle update", ex);
+        }
+    }
+
+    private Set<ZSetOperations.TypedTuple<Object>> fetchReadyVehicles(long currentEpochMillis)
+    {
+        return redisTemplate.opsForZSet().rangeByScoreWithScores(VEHICLE_QUEUE, 0, currentEpochMillis - msPeriod);
+    }
+
+    private void processVehicle(ZSetOperations.TypedTuple<Object> tuple, Set<UUID> deletionSet, long msEpochTimeoutTime)
+    {
+        long nsVehicleStartTime = System.nanoTime();
+        UUID vehicleId = UUID.fromString((String) tuple.getValue());
+
+        // Atomically remove from the queue
+        redisTemplate.opsForZSet().remove(VEHICLE_QUEUE, vehicleId.toString());
+
+        Vehicle vehicle = getVehicle(vehicleId);
+        if (vehicle != null)
+        {
+            // Retrieve additional data
+            vehicle.setDirections(getVehicleDirections(vehicleId));
+            vehicle.setListLineSegmentData(lineSegmentDataMap.get(vehicleId));
+
+            boolean updated = vehicle.update();
+            if (updated)
+            {
+                vehicle.setLastNsExecutionTime(System.nanoTime() - nsVehicleStartTime);
+                setVehicle(vehicle);
+            }
+            else
+            {
+                if (vehicle.getLastCalculationEpochMillis() < msEpochTimeoutTime)
+                {
+                    deletionSet.add(vehicleId);
+                    logger.info("Deleting vehicle ID {}", vehicle.getId());
+                }
+                else
+                {
+                    setVehicle(vehicle);
+                }
+            }
+        }
+    }
+
+    private void cleanupDeletedVehicles(Set<UUID> deletionSet)
+    {
+        // Remove from Active Vehicle Registry
+        for (UUID vehicleID : deletionSet)
+        {
+            redisTemplate.opsForSet().remove(ACTIVE_VEHICLE_REGISTRY, vehicleID.toString());
+        }
+
+        // Remove from directionsMap and lineSegmentDataMap (assuming thread-safe maps
+        // or appropriate synchronization)
+        deletionSet.forEach(vehicleID ->
+        {
+            directionsMap.remove(vehicleID);
+            lineSegmentDataMap.remove(vehicleID);
+        });
+
+        // Remove the vehicle states from Redis
+        deletionSet.forEach(vehicleID ->
+        {
+            String key = getVehicleKey(vehicleID);
+            redisTemplate.opsForValue().getAndDelete(key);
+        });
     }
 }

--- a/src/main/java/com/tarterware/roadrunner/controllers/VehicleController.java
+++ b/src/main/java/com/tarterware/roadrunner/controllers/VehicleController.java
@@ -44,21 +44,12 @@ public class VehicleController
         Vehicle vehicle = vehicleManager.createVehicle(tripPlan);
         VehicleState vehicleState = createVehicleStateFor(vehicle);
 
-        if (vehicleManager.isRunning() == false)
-        {
-            vehicleManager.startup();
-        }
         return new ResponseEntity<VehicleState>(vehicleState, HttpStatus.OK);
     }
 
     @PostMapping("/create-crisscross")
     ResponseEntity<List<VehicleState>> createCrissCrossVehicles(@RequestBody CrissCrossPlan crissCrossPlan)
     {
-        if (vehicleManager.isRunning() == false)
-        {
-            vehicleManager.startup();
-        }
-
         List<VehicleState> listVehicleStates = new ArrayList<VehicleState>();
 
         // Create a Coordinate representing the center point.
@@ -155,7 +146,9 @@ public class VehicleController
     @GetMapping("/reset-server")
     ResponseEntity<List<VehicleState>> resetServer()
     {
-        vehicleManager.shutdown();
+        // TODO -
+        // Add routine that deletes all redis resources?
+        // vehicleManager.shutdown();
 
         return new ResponseEntity<List<VehicleState>>(new ArrayList<VehicleState>(), HttpStatus.OK);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,8 +4,6 @@ spring.data.rest.base-path=/
 
 mapbox.api.url=https://api.mapbox.com/
 
-com.tarterware.data-dir=/opt/tarterware-data
-
 management.endpoints.web.exposure.include=health,info,metrics
 
 com.tarterware.redis.host=127.0.0.1

--- a/src/test/java/com/tarterware/roadrunner/RoadrunnerApplicationTests.java
+++ b/src/test/java/com/tarterware/roadrunner/RoadrunnerApplicationTests.java
@@ -14,6 +14,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.tarterware.roadrunner.configs.NoOpSchedulerConfig;
+import com.tarterware.roadrunner.configs.RedisConfig;
 import com.tarterware.roadrunner.configs.SecurityConfig;
 import com.tarterware.roadrunner.services.DirectionsService;
 import com.tarterware.roadrunner.services.GeocodingService;
@@ -34,6 +35,9 @@ class RoadrunnerApplicationTests
 
     @MockitoBean
     private SecurityConfig securityConfig;
+
+    @MockitoBean
+    private RedisConfig redisConfig;
 
     @MockitoBean
     private LettuceConnectionFactory redisStandAloneConnectionFactory;

--- a/src/test/java/com/tarterware/roadrunner/RoadrunnerApplicationTests.java
+++ b/src/test/java/com/tarterware/roadrunner/RoadrunnerApplicationTests.java
@@ -6,20 +6,21 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import com.tarterware.roadrunner.configs.NoOpSchedulerConfig;
 import com.tarterware.roadrunner.configs.SecurityConfig;
 import com.tarterware.roadrunner.services.DirectionsService;
 import com.tarterware.roadrunner.services.GeocodingService;
 import com.tarterware.roadrunner.services.IsochroneService;
 
 @SpringBootTest
-@ActiveProfiles("test")
+@Import(NoOpSchedulerConfig.class)
 class RoadrunnerApplicationTests
 {
     @MockitoBean

--- a/src/test/java/com/tarterware/roadrunner/components/VehicleTest.java
+++ b/src/test/java/com/tarterware/roadrunner/components/VehicleTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.DefaultTypedTuple;
@@ -30,9 +31,9 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import com.tarterware.roadrunner.configs.NoOpSchedulerConfig;
 import com.tarterware.roadrunner.configs.SecurityConfig;
 import com.tarterware.roadrunner.models.TripPlan;
 import com.tarterware.roadrunner.models.mapbox.Directions;
@@ -45,7 +46,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import utils.TestUtils;
 
 @SpringBootTest
-@ActiveProfiles("test")
+@Import(NoOpSchedulerConfig.class)
 class VehicleTest
 {
     @MockitoBean

--- a/src/test/java/com/tarterware/roadrunner/components/VehicleTest.java
+++ b/src/test/java/com/tarterware/roadrunner/components/VehicleTest.java
@@ -34,6 +34,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.tarterware.roadrunner.configs.NoOpSchedulerConfig;
+import com.tarterware.roadrunner.configs.RedisConfig;
 import com.tarterware.roadrunner.configs.SecurityConfig;
 import com.tarterware.roadrunner.models.TripPlan;
 import com.tarterware.roadrunner.models.mapbox.Directions;
@@ -60,6 +61,9 @@ class VehicleTest
 
     @MockitoBean
     private SecurityConfig securityConfig;
+
+    @MockitoBean
+    private RedisConfig redisConfig;
 
     @MockitoBean
     private LettuceConnectionFactory redisStandAloneConnectionFactory;

--- a/src/test/java/com/tarterware/roadrunner/configs/NoOpSchedulerConfig.java
+++ b/src/test/java/com/tarterware/roadrunner/configs/NoOpSchedulerConfig.java
@@ -1,0 +1,109 @@
+package com.tarterware.roadrunner.configs;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.Trigger;
+
+@TestConfiguration
+public class NoOpSchedulerConfig
+{
+
+    @Bean
+    TaskScheduler taskScheduler()
+    {
+        // Returns a no-op TaskScheduler, so scheduled tasks won't run.
+        return new TaskScheduler()
+        {
+            @Override
+            public ScheduledFuture<?> schedule(Runnable task, Trigger trigger)
+            {
+                return createNoOpScheduledFuture();
+            }
+
+            @Override
+            public ScheduledFuture<?> schedule(Runnable task, Instant startTime)
+            {
+                return createNoOpScheduledFuture();
+            }
+
+            @Override
+            public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Instant startTime, Duration period)
+            {
+                return createNoOpScheduledFuture();
+            }
+
+            @Override
+            public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Duration period)
+            {
+                return createNoOpScheduledFuture();
+            }
+
+            @Override
+            public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Instant startTime, Duration delay)
+            {
+                return createNoOpScheduledFuture();
+            }
+
+            @Override
+            public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Duration delay)
+            {
+                return createNoOpScheduledFuture();
+            }
+
+            private ScheduledFuture<?> createNoOpScheduledFuture()
+            {
+                return new ScheduledFuture<Object>()
+                {
+                    @Override
+                    public long getDelay(TimeUnit unit)
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public int compareTo(Delayed o)
+                    {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean cancel(boolean mayInterruptIfRunning)
+                    {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isCancelled()
+                    {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isDone()
+                    {
+                        return true;
+                    }
+
+                    @Override
+                    public Object get()
+                    {
+                        return null;
+                    }
+
+                    @Override
+                    public Object get(long timeout, TimeUnit unit)
+                    {
+                        return null;
+                    }
+                };
+            }
+        };
+    }
+}


### PR DESCRIPTION
Remove startup and shutdown methods in VehicleManager as they are no longer relevant. Refactor update vehicle loop into smaller, self-contained methods to enhance readability. Switched internal Maps to use ConcurrentMap so that looping can be simplified. Remove "test" profile label that was used to inhibit Timer startup during unit testing. Add a NoOps scheduler to use during Junit testing.