### PR TITLE
Prevent thread premption from skewing max execution times.

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,6 @@ spring.profiles.active=dev
 # Settings for updating the Kubernetes secret
 prometheus.secret.namespace=roadrunner
 prometheus.secret.name=prometheus-token-secret
+
+# Uncomment to display updateVehicle execution statistics in log.
+# logging.level.com.tarterware.roadrunner.components.VehicleManager=DEBUG


### PR DESCRIPTION
Update statistics collector so that execution times greater than 110% of expected will not be considered in statistics. Add debug logging of various times: frame spacing, and last/average/min/max execution times. Add line to application.properties to illustrate how to turn on execution time logging.