### PR TITLE
Change method of discarding outliers to discard top 5% of times.

### DIFF
--- a/src/main/java/com/tarterware/roadrunner/components/VehicleManager.java
+++ b/src/main/java/com/tarterware/roadrunner/components/VehicleManager.java
@@ -77,6 +77,9 @@ public class VehicleManager
     @Value("${com.tarterware.roadrunner.update-period}")
     private String msPeriodString;
 
+    @Value("${com.tarterware.roadrunner.update-capacity:20}")
+    private int updateStatCapacity;
+
     // Update period in milliseconds.
     private long msPeriod;
 
@@ -166,7 +169,7 @@ public class VehicleManager
         msPeriod = duration.toMillis();
 
         // Create the statistics collector to aid in publishing metrics.
-        this.statisticsCollector = new StatisticsCollector(10, msPeriod);
+        this.statisticsCollector = new StatisticsCollector(updateStatCapacity, msPeriod);
 
         logger.info("Starting VehicleManager with a period of {} milliseconds.", msPeriod);
     }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -43,5 +43,10 @@
     "name": "prometheus.secret.namespace",
     "type": "java.lang.String",
     "description": "A description for 'prometheus.secret.namespace'"
+  },
+  {
+    "name": "com.tarterware.roadrunner.update-capacity",
+    "type": "java.lang.String",
+    "description": "A description for 'com.tarterware.roadrunner.update-capacity'"
   }
 ]}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,7 @@ com.tarterware.redis.host=127.0.0.1
 com.tarterware.redis.port=6379
 
 com.tarterware.roadrunner.update-period=250ms
+com.tarterware.roadrunner.update-capacity=20
 
 spring.profiles.active=dev
 


### PR DESCRIPTION
Update StatisticsCollector to use DoubleSummaryStatistics. Expose property com.tarterware.roadrunner.update-capacity as the number of updates to consider in statistics.