### PR TITLE
Switch metric to jitter in execution period.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,42 @@ The following variables need to be set in the `application.properties` file for 
   Management endpoints exposed via HTTP.  
   Example: `health,info`
 
+- **`management.endpoint.health.show-details`**  
+  Show health endpoint details.  
+  Example: `always`
+
 - **`com.tarterware.redis.host`**  
   Host address of the Redis server.  
   Example: `127.0.0.1`
 
+- **`com.tarterware.redis.port`**  
+  Port of the Redis server.  
+  Example: `6379`
+
 - **`spring.profiles.active`**
   Active Spring profile.  Should be 'eks' for AWS builds.
   Example: `eks`
+
+- **`com.tarterware.roadrunner.vehicle-polling-period`**
+  How often to poll the ready list for vehicles
+  Example: `100ms`
+
+- **`com.tarterware.roadrunner.vehicle-update-period`**  
+  How often each vehicle should be updated.
+  Example: `250ms`
+
+- **`com.tarterware.roadrunner.jitter-stat-capacity`**  
+  Number of reading to consider in jitter statistics
+  Example: `200`
+
+- **`prometheus.secret.namespace`**  
+  Namespace of secret for prometheus to obtain Bearer token.
+  Example: `roadrunner`
+
+- **`prometheus.secret.name`**  
+  Namespace of secret for prometheus to obtain Bearer token.
+  Example: `prometheus-token-secret`
+ 
 
 ## 'Secret' Properties Configuration
 
@@ -48,6 +77,18 @@ The following variables should be set in a 'secrets.properties' file that is pee
 - **`spring.security.oauth2.resourceserver.jwt.issuer-uri`**
   OAuth2 JWT issuer
   Example: `https://dev-PROJECTID.us.auth0.com/`
+
+- **`auth0.api.audience`**
+  OAuth2 JWT issuer
+  Example: `https://auth.PROJECTED.com/`
+
+- **`auth0.api.client-id`**
+  Auth0 Client ID
+  Example: `a-client-id-but-not-this`
+
+- **`auth0.api.client-secret`**
+  Auth0 Client Secret
+  Example: `nunyabiznezz`
 
 - **`com.tarterware.redis.password`**
   Password to access redis outside AWS

--- a/src/main/java/com/tarterware/roadrunner/components/Vehicle.java
+++ b/src/main/java/com/tarterware/roadrunner/components/Vehicle.java
@@ -121,6 +121,7 @@ public class Vehicle
     // Timestamp of the last position update calculation.
     @JsonProperty
     @Getter
+    @Setter
     long lastCalculationEpochMillis;
 
     // Last time of executions for this Vehicle, in nanoseconds

--- a/src/main/java/com/tarterware/roadrunner/controllers/VehicleController.java
+++ b/src/main/java/com/tarterware/roadrunner/controllers/VehicleController.java
@@ -114,7 +114,7 @@ public class VehicleController
     @GetMapping("/get-vehicle-directions/{vehicleId}")
     ResponseEntity<Directions> getVehicleDirectionsFor(@PathVariable String vehicleId)
     {
-        Directions directions = vehicleManager.getVehicleDirections(UUID.fromString(vehicleId));
+        Directions directions = vehicleManager.getVehicleDirections(UUID.fromString(vehicleId), true);
         if (directions == null)
         {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
@@ -146,9 +146,7 @@ public class VehicleController
     @GetMapping("/reset-server")
     ResponseEntity<List<VehicleState>> resetServer()
     {
-        // TODO -
-        // Add routine that deletes all redis resources?
-        // vehicleManager.shutdown();
+        vehicleManager.reset();
 
         return new ResponseEntity<List<VehicleState>>(new ArrayList<VehicleState>(), HttpStatus.OK);
     }

--- a/src/main/java/com/tarterware/roadrunner/utilities/JitterStatisticsCollector.java
+++ b/src/main/java/com/tarterware/roadrunner/utilities/JitterStatisticsCollector.java
@@ -1,0 +1,128 @@
+package com.tarterware.roadrunner.utilities;
+
+/**
+ * A utility class for collecting jitter statistics (mean, standard deviation,
+ * min, and max) over a fixed-size circular buffer.
+ */
+public class JitterStatisticsCollector
+{
+
+    private final int capacity;
+    private final double[] measurements;
+    private int index = 0;
+    private int count = 0;
+
+    // Recalculated statistics over the entire window.
+    private double mean = 0.0;
+    private double m2 = 0.0; // Variance times (n-1)
+
+    private double min = Double.MAX_VALUE;
+    private double max = Double.MIN_VALUE;
+
+    public JitterStatisticsCollector(int capacity)
+    {
+        if (capacity < 1)
+        {
+            throw new IllegalArgumentException("Capacity must be at least 1");
+        }
+        this.capacity = capacity;
+        this.measurements = new double[capacity];
+    }
+
+    /**
+     * Records a new measurement. If the collector is full, it replaces the oldest
+     * value and then recalculates statistics over the entire window.
+     *
+     * @param value the jitter measurement in milliseconds
+     */
+    public synchronized void recordMeasurement(double value)
+    {
+        // Write the new measurement into the circular buffer.
+        measurements[index] = value;
+        index = (index + 1) % capacity;
+        if (count < capacity)
+        {
+            count++;
+        }
+        // Recalculate all statistics over the current window.
+        recalcAll();
+    }
+
+    private void recalcAll()
+    {
+        double sum = 0.0;
+        double sumSq = 0.0;
+        double currentMin = Double.MAX_VALUE;
+        double currentMax = Double.MIN_VALUE;
+        // When the buffer isn't full, only consider the first 'count' elements;
+        // when full, all 'capacity' elements are valid.
+        int n = (count < capacity) ? count : capacity;
+        for (int i = 0; i < n; i++)
+        {
+            double v = measurements[i];
+            sum += v;
+            sumSq += v * v;
+            if (v < currentMin)
+            {
+                currentMin = v;
+            }
+            if (v > currentMax)
+            {
+                currentMax = v;
+            }
+        }
+        mean = (n > 0) ? sum / n : 0.0;
+        // Compute sample variance (m2 is variance*(n-1))
+        if (n > 1)
+        {
+            double variance = (sumSq - n * mean * mean) / (n - 1);
+            m2 = variance;
+        }
+        else
+        {
+            m2 = 0.0;
+        }
+        min = currentMin;
+        max = currentMax;
+    }
+
+    /**
+     * Returns the average of the recorded measurements.
+     */
+    public synchronized double getMean()
+    {
+        return mean;
+    }
+
+    /**
+     * Returns the standard deviation of the recorded measurements.
+     */
+    public synchronized double getStandardDeviation()
+    {
+        return count > 1 ? Math.sqrt(m2) : 0.0;
+    }
+
+    /**
+     * Returns the minimum recorded measurement.
+     */
+    public synchronized double getMin()
+    {
+        return count > 0 ? min : 0.0;
+    }
+
+    /**
+     * Returns the maximum recorded measurement.
+     */
+    public synchronized double getMax()
+    {
+        return count > 0 ? max : 0.0;
+    }
+
+    /**
+     * Returns the current number of recorded measurements.
+     */
+    public synchronized int getCount()
+    {
+        return count;
+    }
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -25,11 +25,6 @@
     "description": "A description for 'com.tarterware.redis.port'"
   },
   {
-    "name": "com.tarterware.roadrunner.update-period",
-    "type": "java.lang.String",
-    "description": "A description for 'com.tarterware.roadrunner.update-period'"
-  },
-  {
     "name": "prometheus.secret.namespace",
     "type": "java.lang.String",
     "description": "A description for 'prometheus.secret.namespace'"
@@ -45,8 +40,18 @@
     "description": "A description for 'prometheus.secret.namespace'"
   },
   {
-    "name": "com.tarterware.roadrunner.update-capacity",
+    "name": "com.tarterware.roadrunner.jitter-stat-capacity",
     "type": "java.lang.String",
-    "description": "A description for 'com.tarterware.roadrunner.update-capacity'"
+    "description": "A description for 'com.tarterware.roadrunner.jitter-stat-capacity'"
+  },
+  {
+    "name": "com.tarterware.roadrunner.vehicle-update-period",
+    "type": "java.lang.String",
+    "description": "A description for 'com.tarterware.roadrunner.vehicle-update-period'"
+  },
+  {
+    "name": "com.tarterware.roadrunner.vehicle-polling-period",
+    "type": "java.lang.String",
+    "description": "A description for 'com.tarterware.roadrunner.vehicle-polling-period'"
   }
 ]}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,8 +11,10 @@ com.tarterware.redis.host=127.0.0.1
 
 com.tarterware.redis.port=6379
 
-com.tarterware.roadrunner.update-period=250ms
-com.tarterware.roadrunner.update-capacity=20
+com.tarterware.roadrunner.vehicle-polling-period=100ms
+com.tarterware.roadrunner.vehicle-update-period=250ms
+
+com.tarterware.roadrunner.jitter-stat-capacity=200
 
 spring.profiles.active=dev
 
@@ -21,4 +23,4 @@ prometheus.secret.namespace=roadrunner
 prometheus.secret.name=prometheus-token-secret
 
 # Uncomment to display updateVehicle execution statistics in log.
-# logging.level.com.tarterware.roadrunner.components.VehicleManager=DEBUG
+logging.level.com.tarterware.roadrunner.components.VehicleManager=DEBUG

--- a/src/test/java/com/tarterware/roadrunner/components/VehicleTest.java
+++ b/src/test/java/com/tarterware/roadrunner/components/VehicleTest.java
@@ -143,7 +143,7 @@ class VehicleTest
         tuple.add(new DefaultTypedTuple<>(vehicleId.toString(), 1000.0));
         when(zSetOperations.rangeByScoreWithScores(any(), anyDouble(), anyDouble())).thenReturn(tuple);
 
-        vehicle.setDirections(vehicleManager.getVehicleDirections(vehicleId));
+        vehicle.setDirections(vehicleManager.getVehicleDirections(vehicleId, true));
         vehicle.setListLineSegmentData(vehicleManager.getLineSegmentData(vehicleId));
     }
 


### PR DESCRIPTION
Change controls for intervals to specify how ofter vehicles should update, and how often the list of waiting vehicles should be polled.  Polling should be more frequent.  Current default are 100 and 250 ms. Restore reset to VehicleManager, whicj clears out all redis variables. Change vehicle Directions creation to happen asynchronously.